### PR TITLE
Fix input-source icons across light and dark modes

### DIFF
--- a/ArmenianPhonetic.bundle/Contents/Info.plist
+++ b/ArmenianPhonetic.bundle/Contents/Info.plist
@@ -13,7 +13,7 @@
 		<key>TICapsLockLanguageSwitchCapable</key>
 		<false/>
 		<key>TISIconIsTemplate</key>
-		<false/>
+		<true/>
 		<key>TISInputSourceID</key>
 		<string>org.sil.ukelele.keyboardlayout.armenianphonetic.armenianphonetic</string>
 		<key>TISIntendedLanguage</key>
@@ -24,7 +24,7 @@
 		<key>TICapsLockLanguageSwitchCapable</key>
 		<false/>
 		<key>TISIconIsTemplate</key>
-		<false/>
+		<true/>
 		<key>TISInputSourceID</key>
 		<string>org.sil.ukelele.keyboardlayout.armenianphonetic.armenianphonetic(kdwin)</string>
 		<key>TISIntendedLanguage</key>
@@ -35,7 +35,7 @@
 		<key>TICapsLockLanguageSwitchCapable</key>
 		<false/>
 		<key>TISIconIsTemplate</key>
-		<false/>
+		<true/>
 		<key>TISInputSourceID</key>
 		<string>org.sil.ukelele.keyboardlayout.armenianphonetic.armenianphonetic(kdwin)withenglish</string>
 		<key>TISIntendedLanguage</key>
@@ -46,7 +46,7 @@
 		<key>TICapsLockLanguageSwitchCapable</key>
 		<false/>
 		<key>TISIconIsTemplate</key>
-		<false/>
+		<true/>
 		<key>TISInputSourceID</key>
 		<string>org.sil.ukelele.keyboardlayout.armenianphonetic.armenianphoneticwithenglish</string>
 		<key>TISIntendedLanguage</key>

--- a/doc/building.md
+++ b/doc/building.md
@@ -62,7 +62,9 @@ iconutil -c icns './resources/Armenian Phonetic.iconset' -o 'ArmenianPhonetic.bu
 
 Notes:
 - PNGs may be any shape (transparency supported), but the canvas must be square and exactly the sizes listed above.
-- Use standard 8‑bit RGBA, sRGB. Avoid CMYK/16‑bit images.
+- Input-source icons are template masks: use an opaque rounded badge with the glyph punched out transparently. macOS tints the badge and lets the menu background show through the glyph, matching the built-in layouts in light, dark, and highlighted states.
+- Set `TISIconIsTemplate` to `true` for every `KLInfo_*` entry in `ArmenianPhonetic.bundle/Contents/Info.plist`; this lets macOS tint the badge for the current appearance and selection state.
+- Use standard 8-bit RGBA, sRGB. Avoid CMYK/16-bit images.
 
 
 ### Troubleshooting


### PR DESCRIPTION
## Summary

Fixes #44 

Enables template rendering for all 4 Armenian Phonetic input sources. Original icons are preserved. The icons now match built in layouts across light, dark, normal, and highlighted menu states.

## Screenshots

### Light theme

<img width="254" height="78" alt="3ff88006-5ccc-46ab-a263-677150ca1cb1-e9bf4ca7-e80e-4875-ad9e-58d6aba811d6" src="https://github.com/user-attachments/assets/3e321468-139c-4f6d-8203-72741daea7c7" />

<img width="239" height="76" alt="3ff88006-5ccc-46ab-a263-677150ca1cb1-c5f2bb36-ba2b-4124-b46a-8d7c5a36b53c" src="https://github.com/user-attachments/assets/67eb2765-849c-4016-abe0-c22f5e0ff344" />

### Dark theme

<img width="252" height="76" alt="3ff88006-5ccc-46ab-a263-677150ca1cb1-08d638f4-7f81-436b-859b-bade8605f6ff" src="https://github.com/user-attachments/assets/60db76c1-cc9c-4a54-823c-343180c818e8" />

<img width="247" height="73" alt="3ff88006-5ccc-46ab-a263-677150ca1cb1-c370eb36-1396-4fd3-82ec-fe9c4f9f2d44" src="https://github.com/user-attachments/assets/26920ae5-b8cb-4adc-b11c-d32ee23edfca" />